### PR TITLE
sets CSP to upgrade-insecure-requests

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -25,6 +25,7 @@ not populated by JavaScript #}
 {% block title %}{% if sample is defined and sample is not none %}MSM - {{ sample.name }}{% else %}Mercury Sample Manager{% endif %}{% endblock %}
 
 {% block styles %}
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     {{super()}}
     <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
     <link rel="stylesheet" href="{{url_for('static', filename='base.css')}}">


### PR DESCRIPTION
Here is the Problem: When using  https, ckeditor fails to load some of its components
asynchronously because of strict content-security-policy (CSP) settings in the client (the
default behavior in many modern browsers is to not allow mixed content, or warn at least).
The easy fix is to set the CSP to 'upgrade-insecure-requests'. The client then rewrites requests
to https before they hit the network.
Http-only setups (e.g. for local development) don't seem to be impacted by this. 